### PR TITLE
Removed the aliases and renamed the "real" dylib file

### DIFF
--- a/Raylib-CsLo/runtimes/osx-arm64/native/libraylib.4.2.0.dylib
+++ b/Raylib-CsLo/runtimes/osx-arm64/native/libraylib.4.2.0.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6031c8f523f3e9996bf578ffb2714c9d7ea9e67012e36aaf0c6d38645cfd88a7
-size 1581240

--- a/Raylib-CsLo/runtimes/osx-arm64/native/libraylib.420.dylib
+++ b/Raylib-CsLo/runtimes/osx-arm64/native/libraylib.420.dylib
@@ -1,1 +1,0 @@
-libraylib.4.2.0.dylib

--- a/Raylib-CsLo/runtimes/osx-arm64/native/libraylib.dylib
+++ b/Raylib-CsLo/runtimes/osx-arm64/native/libraylib.dylib
@@ -1,1 +1,3 @@
-libraylib.4.2.0.dylib
+version https://git-lfs.github.com/spec/v1
+oid sha256:6031c8f523f3e9996bf578ffb2714c9d7ea9e67012e36aaf0c6d38645cfd88a7
+size 1581240

--- a/Raylib-CsLo/runtimes/osx-arm64/native/raylib.dylib
+++ b/Raylib-CsLo/runtimes/osx-arm64/native/raylib.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59185df059022e9c56d957b10b98e59681c0343a0b774a91fad107c8801561cd
-size 21


### PR DESCRIPTION
Removed the aliases and renamed the "real" dylib file to 'libraylib' as that seems to be the one MacOS is actually looking for as described in comment of issue #32 